### PR TITLE
Static build support

### DIFF
--- a/src/libsnore/SnoreAddPlugin.cmake
+++ b/src/libsnore/SnoreAddPlugin.cmake
@@ -60,6 +60,7 @@ function(add_snore_plugin SNORE_NAME)
         set_property( TARGET libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE}
                       APPEND
                       PROPERTY COMPILE_DEFINITIONS QT_STATICPLUGIN)
+        set_target_properties(libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} PROPERTIES PREFIX "")
     endif()
 
     target_link_libraries(libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} Snore::Libsnore ${SNORE_LIBS})

--- a/src/libsnore/SnoreAddPlugin.cmake
+++ b/src/libsnore/SnoreAddPlugin.cmake
@@ -73,11 +73,13 @@ function(add_snore_plugin SNORE_NAME)
             install(TARGETS libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} ${SNORE_PLUGIN_INSTALL_PATH})
         else()
              add_library(libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} STATIC ${SNORE_SETTINGS_SOURCES} )
+             install(TARGETS libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
              set_property( TARGET libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE}
                            APPEND
                            PROPERTY COMPILE_DEFINITIONS QT_STATICPLUGIN)
              list(APPEND SNORE_PLUGINS libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} )
              list(APPEND SNORE_PLUGIN_LIST "${SNORE_NAME_NO_SPACE}SettingsPlugin")
+             set_target_properties(libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} PROPERTIES PREFIX "")
         endif()
         target_link_libraries(libsnore_settings_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} Snore::Libsnore Snore::LibsnoreSettings ${SNORE_SETTINGS_LIBS})
     endif()

--- a/src/libsnore/SnoreAddPlugin.cmake
+++ b/src/libsnore/SnoreAddPlugin.cmake
@@ -56,7 +56,7 @@ function(add_snore_plugin SNORE_NAME)
         list(APPEND SNORE_PLUGIN_LIST "${SNORE_NAME_NO_SPACE}")
         add_library(libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} STATIC ${SNORE_SOURCES})
         #todo install and export the plugins
-        #install(TARGETS libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+        install(TARGETS libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
         set_property( TARGET libsnore_${SNORE_TYPE_LOWERCASE}_${SNORE_NAME_LOWERCASE}
                       APPEND
                       PROPERTY COMPILE_DEFINITIONS QT_STATICPLUGIN)

--- a/src/libsnore/notification/notification_p.cpp
+++ b/src/libsnore/notification/notification_p.cpp
@@ -22,17 +22,25 @@
 #include "libsnore/plugins/plugins.h"
 #include "libsnore/snore.h"
 
+#include <QDateTime>
 #include <QSharedData>
 
 using namespace Snore;
 
 uint NotificationData::notificationCount = 0;
 
-uint NotificationData::m_idCount = 1;
+namespace {
+uint m_idCount = 1;
+}
+uint getNewId() {
+    const QDateTime& d = QDateTime::currentDateTime();
+    QString result = QString(QStringLiteral("%1%2")).arg(d.toString(QStringLiteral("Hmmsszzz"))).arg(m_idCount++);
+    return result.toUInt();
+}
 
 NotificationData::NotificationData(const Snore::Application &application, const Snore::Alert &alert, const QString &title, const QString &text, const Icon &icon,
                                    int timeout, Notification::Prioritys priority):
-    m_id(m_idCount++),
+    m_id(getNewId()),
     m_timeout(priority == Notification::Emergency ? 0 : timeout),
     m_application(application),
     m_alert(alert),
@@ -48,7 +56,7 @@ NotificationData::NotificationData(const Snore::Application &application, const 
 }
 
 Snore::NotificationData::NotificationData(const Notification &old, const QString &title, const QString &text, const Icon &icon, int timeout, Notification::Prioritys priority):
-    m_id(m_idCount++),
+    m_id(getNewId()),
     m_timeout(priority == Notification::Emergency ? 0 : timeout),
     m_application(old.application()),
     m_alert(old.alert()),

--- a/src/libsnore/notification/notification_p.h
+++ b/src/libsnore/notification/notification_p.h
@@ -94,7 +94,6 @@ private:
     SnorePlugin *m_source = nullptr;
 
     static uint notificationCount;
-    static uint m_idCount;
 
     friend class Notification;
     friend class SnoreCorePrivate;

--- a/src/libsnore/snore_p.cpp
+++ b/src/libsnore/snore_p.cpp
@@ -33,7 +33,7 @@
 using namespace Snore;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-Q_LOGGING_CATEGORY(SNORE, "libsnorenotify", QtWarningMsg)
+Q_LOGGING_CATEGORY(SNORE, "libsnorenotify", QtDebugMsg)
 #else
 Q_LOGGING_CATEGORY(SNORE, "libsnorenotify")
 #endif

--- a/src/libsnore/snore_p.cpp
+++ b/src/libsnore/snore_p.cpp
@@ -33,7 +33,7 @@
 using namespace Snore;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-Q_LOGGING_CATEGORY(SNORE, "libsnorenotify", QtDebugMsg)
+Q_LOGGING_CATEGORY(SNORE, "libsnorenotify", QtWarningMsg)
 #else
 Q_LOGGING_CATEGORY(SNORE, "libsnorenotify")
 #endif

--- a/src/libsnore/snore_static_plugins.h.in
+++ b/src/libsnore/snore_static_plugins.h.in
@@ -31,16 +31,16 @@ namespace SnorePlugin {}
 using namespace SnorePlugin;
 ${SNORE_PLUGIN_LOADING}
 
-namespace {
-    static void loadSnoreResources()
-    {
-        // prevent multiple symbols
-         static const auto load = []() {
-             ${SNORE_RESOURCE_LOADING}
-         };
-         load();
-    }
+
+static void loadSnoreResources()
+{
+    // prevent multiple symbols
+     static const auto load = []() {
+         ${SNORE_RESOURCE_LOADING}
+     };
+     load();
 }
+
 Q_COREAPP_STARTUP_FUNCTION(loadSnoreResources)
 #endif
 

--- a/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.mm
+++ b/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.mm
@@ -85,12 +85,13 @@ BOOL installNSBundleHook()
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
         ^{
             int notificationId = [notification.userInfo[@"id"] intValue];
-            BOOL notificationAvailable = YES;
+            bool notificationAvailable = true;
             while(notificationAvailable) {
-                notificationAvailable = NO;
+                notificationAvailable = false;
                 for(NSUserNotification *osxNotification in [[NSUserNotificationCenter defaultUserNotificationCenter] deliveredNotifications]) {
-                    if([osxNotification.identifier isEqualToString:notification.identifier]) {
-                        notificationAvailable = YES;
+                    int fetchedNotificationID = [osxNotification.userInfo[@"id"] intValue];
+                    if(fetchedNotificationID == notificationId) {
+                        notificationAvailable = true;
                         [NSThread sleepForTimeInterval:0.25f];
                         break;
                     }
@@ -154,7 +155,7 @@ void OSXNotificationCenter::slotNotify(Snore::Notification notification)
     osxNotification.title = notification.title().toNSString();
     osxNotification.userInfo = [NSDictionary dictionaryWithObjectsAndKeys:notificationId, @"id", nil];
     osxNotification.informativeText = notification.text().toNSString();
-    osxNotification.identifier = notificationId;
+    // osxNotification.identifier = notificationId;
     
     // Add notification to mapper from id to Nofification / NSUserNotification
     m_IdToNotification.insert(notification.id(), notification);

--- a/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.mm
+++ b/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.mm
@@ -102,11 +102,11 @@ BOOL installNSBundleHook()
                     qCWarning(SNORE) << "Delivered notification is not recognized and will not be remove from active list. Notification id:" << notificationId;
                     return;
                 }
+                qCWarning(SNORE) << "Notification with following id is delivered or dismissed:" << notificationId;
+                auto snoreNotification = m_IdToNotification.take(notificationId);
+                snoreNotification.removeActiveIn(notificationCenter);
+                snoreNotification.removeActiveIn(&SnoreCore::instance());
             });
-            qCWarning(SNORE) << "Notification with following id is delivered or dismissed:" << notificationId;
-            auto snoreNotification = m_IdToNotification.take(notificationId);
-            snoreNotification.removeActiveIn(notificationCenter);
-            snoreNotification.removeActiveIn(&SnoreCore::instance());
         });
 }
 @end


### PR DESCRIPTION
- Install static libs
- Resolve naming issue of static libs
- Unify generated notification id based on current date-time
- Rely on userInfo when storing notification id for OSX notification center
- Remove notification data from dictionary in single main thread
- Remove anonymous namespace from snore_static_plugins.h (caused linkage issue on OS X) 