### PR TITLE
add setDockBadgeLabel method

### DIFF
--- a/src/libsnore/plugins/snorebackend.h
+++ b/src/libsnore/plugins/snorebackend.h
@@ -53,6 +53,7 @@ public Q_SLOTS:
     virtual void slotDeregisterApplication(const Snore::Application &application);
     virtual void slotNotify(Snore::Notification notification) = 0;
     virtual void slotCloseNotification(Snore::Notification notification);
+    virtual void setDockBadgeLabel(const QString label) = 0;
 
 protected Q_SLOTS:
     void slotNotificationDisplayed(Notification notification);

--- a/src/libsnore/snore.cpp
+++ b/src/libsnore/snore.cpp
@@ -137,6 +137,14 @@ void SnoreCore::broadcastNotification(Notification notification)
     emit d->notify(notification);
 }
 
+void SnoreCore::setDockBadgeLabel(const QString label)
+{
+    Q_D(const SnoreCore);
+    if (d->m_notificationBackend != nullptr) {
+      d->m_notificationBackend->setDockBadgeLabel(label);
+    }
+}
+
 void SnoreCore::registerApplication(const Application &application)
 {
     Q_D(SnoreCore);

--- a/src/libsnore/snore.h
+++ b/src/libsnore/snore.h
@@ -82,6 +82,11 @@ public:
     void displayExampleNotification();
 
     /**
+     * Sets dock badge label
+     */
+    void setDockBadgeLabel(const QString label);
+
+    /**
      * Register an application.
      * Each application should only be registered once.
      * An application must be registered before a notification can be broadcasted.

--- a/src/plugins/backends/freedesktop_backend/freedesktopnotification_backend.cpp
+++ b/src/plugins/backends/freedesktop_backend/freedesktopnotification_backend.cpp
@@ -90,6 +90,11 @@ void  SnorePlugin::Freedesktop::slotNotify(Snore::Notification noti)
     qCDebug(SNORE) << noti.id() << "|" << id.value();
 }
 
+void  SnorePlugin::Freedesktop::setDockBadgeLabel(const QString label)
+{
+
+}
+
 void SnorePlugin::Freedesktop::slotActionInvoked(const uint id, const QString &actionID)
 {
     qCDebug(SNORE) << id << m_dbusIdMap[id];

--- a/src/plugins/backends/freedesktop_backend/freedesktopnotification_backend.h
+++ b/src/plugins/backends/freedesktop_backend/freedesktopnotification_backend.h
@@ -20,6 +20,7 @@ public:
 public Q_SLOTS:
     void slotNotify(Snore::Notification notification) override;
     void slotCloseNotification(Snore::Notification notification) override;
+    void setDockBadgeLabel(const QString label) override;
 
     void slotActionInvoked(const uint id, const QString &actionID);
     void slotNotificationClosed(const uint id, const uint reason);

--- a/src/plugins/backends/osxnotificationcenter/CMakeLists.txt
+++ b/src/plugins/backends/osxnotificationcenter/CMakeLists.txt
@@ -1,3 +1,3 @@
 if(APPLE)
-    add_snore_plugin("OSX Notification Center" SOURCES osxnotificationcenter.mm TYPE Backend LIBS /System/Library/Frameworks/Foundation.framework)
+    add_snore_plugin("OSX Notification Center" SOURCES osxnotificationcenter.mm TYPE Backend LIBS /System/Library/Frameworks/Foundation.framework /System/Library/Frameworks/Cocoa.framework)
 endif(APPLE)

--- a/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.h
+++ b/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.h
@@ -33,6 +33,7 @@ public:
 
 public Q_SLOTS:
     void slotNotify(Snore::Notification notification) override;
+    void setDockBadgeLabel(const QString label);
 };
 
 #endif // OSXNOTIFICATIONCENTER_H

--- a/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.mm
+++ b/src/plugins/backends/osxnotificationcenter/osxnotificationcenter.mm
@@ -9,6 +9,7 @@
 #import <QMap>
 #include <Foundation/Foundation.h>
 #import <objc/runtime.h>
+#import "AppKit/NSApplication.h"
 
 using namespace Snore;
 
@@ -164,4 +165,7 @@ void OSXNotificationCenter::slotNotify(Snore::Notification notification)
     slotNotificationDisplayed(notification);
 }
 
-
+void OSXNotificationCenter::setDockBadgeLabel(const QString label)
+{
+  [[[NSApplication sharedApplication] dockTile] setBadgeLabel:label.toNSString()];
+}

--- a/src/plugins/backends/snore/snorenotifier.cpp
+++ b/src/plugins/backends/snore/snorenotifier.cpp
@@ -60,6 +60,11 @@ void SnorePlugin::Snore::slotNotify(::Snore::Notification notification)
     }
 }
 
+void SnorePlugin::Snore::setDockBadgeLabel(const QString label)
+{
+
+}
+
 void SnorePlugin::Snore::slotCloseNotification(::Snore::Notification notification)
 {
     NotifyWidget *w = m_widgets[notification.hints().privateValue(this, "id").toInt()];

--- a/src/plugins/backends/snore/snorenotifier.h
+++ b/src/plugins/backends/snore/snorenotifier.h
@@ -43,6 +43,7 @@ protected:
 public Q_SLOTS:
     virtual void slotNotify(::Snore::Notification notification) override;
     virtual void slotCloseNotification(::Snore::Notification notification) override;
+    virtual void setDockBadgeLabel(const QString label) override;
     void slotRegisterApplication(const ::Snore::Application &application);
 
 private:

--- a/src/plugins/backends/trayicon/trayiconnotifer.cpp
+++ b/src/plugins/backends/trayicon/trayiconnotifer.cpp
@@ -30,6 +30,10 @@ void SnorePlugin::Trayicon::slotNotify(Snore::Notification notification)
     }
 }
 
+void SnorePlugin::Trayicon::setDockBadgeLabel(const QString label) {
+
+}
+
 void SnorePlugin::Trayicon::slotCloseNotification(Snore::Notification n)
 {
     QSystemTrayIcon *icon = trayIcon(n.application());

--- a/src/plugins/backends/trayicon/trayiconnotifer.h
+++ b/src/plugins/backends/trayicon/trayiconnotifer.h
@@ -24,6 +24,7 @@ public Q_SLOTS:
     void slotCloseNotification(Snore::Notification notification) override;
     void slotRegisterApplication(const Snore::Application &application) override;
     void slotDeregisterApplication(const Snore::Application &application) override;
+    void setDockBadgeLabel(const QString label) override;
 
 private:
     QSystemTrayIcon *trayIcon(const Snore::Application &app);


### PR DESCRIPTION
Adds `setDockBadgeLabel` method that is needed to update app dock badge to implement https://github.com/status-im/status-react/issues/4433

Related to https://github.com/status-im/status-react/pull/6146